### PR TITLE
Network Topology Shows duplicate sta's across AP and AP disconnect Scenario 

### DIFF
--- a/internal/services/topology_service.go
+++ b/internal/services/topology_service.go
@@ -147,6 +147,8 @@ func (s *topologyService) BuildTopology(ctx context.Context, boardID string) (mo
 		}
 	}
 
+	knownStation := make(map[string]bool)
+
 	// 3) Pass 2: build devices + faces + clients + mesh edges
 	devMap := make(map[string]*models.Device, len(rows))
 	meshEdgeSet := make(map[string]models.MeshEdge) // dedupe: from|to|ssid|band|channel
@@ -167,6 +169,18 @@ func (s *topologyService) BuildTopology(ctx context.Context, boardID string) (mo
 			Connected: deviceInfoStatus[serial],
 			APs:       []models.Face{},
 			Mesh:      []models.Face{},
+		}
+
+		if deviceInfoStatus[serial] == false {
+			// skip offline devices' faces
+			offlineDev := &models.Device{
+				Serial:    serial,
+				Connected: deviceInfoStatus[serial],
+				APs:       []models.Face{},
+				Mesh:      []models.Face{},
+			}
+			devMap[serial] = offlineDev
+			continue
 		}
 
 		rowTS := time.Unix(r.Timestamp, 0).In(ist).Format(time.RFC3339)
@@ -198,6 +212,9 @@ func (s *topologyService) BuildTopology(ctx context.Context, boardID string) (mo
 
 				switch mode {
 				case "ap":
+					if knownStation[st] == true {
+						continue
+					}
 					// Exclude stations that are any known BSSID; only end-devices remain.
 					if _, isBSSID := knownBSSID[st]; isBSSID {
 						continue
@@ -229,6 +246,7 @@ func (s *topologyService) BuildTopology(ctx context.Context, boardID string) (mo
 						RxRateChwidth: a.RxRate.Chwidth,
 						Fingerprint:   fingerprint,
 					})
+					knownStation[st] = true
 
 				case "mesh":
 					// Include only if peer is a known BSSID -> build directed mesh edge serial->peerOwner

--- a/internal/services/topology_service.go
+++ b/internal/services/topology_service.go
@@ -175,7 +175,7 @@ func (s *topologyService) BuildTopology(ctx context.Context, boardID string) (mo
 			// skip offline devices' faces
 			offlineDev := &models.Device{
 				Serial:    serial,
-				Connected: deviceInfoStatus[serial],
+				Connected: false,
 				APs:       []models.Face{},
 				Mesh:      []models.Face{},
 			}


### PR DESCRIPTION
**Current Scenario :** 
**Device Disconnect Scenario:** 
When one Access Point goes Offline in a mesh network and all it's connected sta gets connected to mesh device it will still show the client connected to both after the other device sends it's state message it's happeing because topology fetches last 4 minutes data 
**Client Roaming Scenario:**
When a client moves (roams) from one Access Point to another in a mesh setup the client is temporarily shown as connected to both Access Points at the same time in the station lists. , it's happening because both the devices will send the state message with sta's connected .

**Expected Behaviour**  
Topology will not show disconnected devices to fix the issue of AP disconnected scenario and topology will handle the scenario of client roaming .



**Network Topology Response For First scenario**  

`{
    "boardId": "a043578b-0f80-4fb3-ab82-40338fe526db",
    "timestamp": "2026-02-04T15:17:09Z",
    "nodes": [
        {
            "serial": "b46ad445e95c",
            "uptime": 3212,
            "aps": [
                {
                    "bssid": "b4:6a:d4:45:e9:5f",
                    "ssid": "Default-SSID",
                    "band": "2",
                    "channel": 6,
                    "mode": "ap",
                    "clients": null,
                    "timestamp": "2026-02-04T21:00:04+05:30"
                },
                {
                    "bssid": "b4:6a:d4:45:e9:60",
                    "ssid": "Default-SSID",
                    "band": "5",
                    "channel": 149,
                    "mode": "ap",
                    "clients": null,
                    "timestamp": "2026-02-04T21:00:04+05:30"
                }
            ],
            "mesh": [
                {
                    "bssid": "b6:6a:d4:45:e9:60",
                    "ssid": "DEFAULT-MESH",
                    "band": "5",
                    "channel": 149,
                    "mode": "mesh",
                    "clients": [
                        {
                            "station": "de:62:79:65:30:7d",
                            "rssi": -28,
                            "connected": 2435,
                            "inactive": 0,
                            "rx_rate_bitrate": 0,
                            "tx_rate_bitrate": 68800,
                            "rx_rate_chwidth": 20
                        }
                    ],
                    "timestamp": "2026-02-04T20:44:35+05:30"
                }
            ],
            "connected": true
        },
        {
            "serial": "dc627965307e",
            "connected": false
        }
    ],
    "edges": {
        "wired": [],
        "mesh": [
            {
                "from": "b46ad445e95c",
                "to": "dc627965307e",
                "ssid": "DEFAULT-MESH",
                "band": "5",
                "channel": 149
            },
        ]
    }
}`


Network Topology Response For Second Scenario : 

`{
    "boardId": "a043578b-0f80-4fb3-ab82-40338fe526db",
    "timestamp": "2026-02-04T15:30:39Z",
    "nodes": [
        {
            "serial": "b46ad445e95c",
            "uptime": 3212,
            "aps": [
                {
                    "bssid": "b4:6a:d4:45:e9:5f",
                    "ssid": "Default-SSID",
                    "band": "2",
                    "channel": 6,
                    "mode": "ap",
                    "clients": null,
                    "timestamp": "2026-02-04T21:00:04+05:30"
                },
                {
                    "bssid": "b4:6a:d4:45:e9:60",
                    "ssid": "Default-SSID",
                    "band": "5",
                    "channel": 149,
                    "mode": "ap",
                    "clients": null,
                    "timestamp": "2026-02-04T21:00:04+05:30"
                }
            ],
            "mesh": [
                {
                    "bssid": "b6:6a:d4:45:e9:60",
                    "ssid": "DEFAULT-MESH",
                    "band": "5",
                    "channel": 149,
                    "mode": "mesh",
                    "clients": [
                        {
                            "station": "de:62:79:65:30:7d",
                            "rssi": -28,
                            "connected": 2435,
                            "inactive": 0,
                            "rx_rate_bitrate": 0,
                            "tx_rate_bitrate": 68800,
                            "rx_rate_chwidth": 20
                        }
                    ],
                    "timestamp": "2026-02-04T21:00:04+05:30"
                }
            ],
            "connected": true
        },
        {
            "serial": "dc627965307e",
            "uptime": 3242,
            "aps": [
                {
                    "bssid": "dc:62:79:65:30:7e",
                    "ssid": "Mesh",
                    "band": "2",
                    "channel": 6,
                    "mode": "ap",
                    "clients": null,
                    "timestamp": "2026-02-04T21:00:35+05:30"
                },
                {
                    "bssid": "dc:62:79:65:30:7d",
                    "ssid": "Mesh",
                    "band": "5",
                    "channel": 149,
                    "mode": "ap",
                    "clients": [
                        {
                            "station": "98:bd:80:6f:3b:d2",
                            "rssi": -54,
                            "connected": 137,
                            "inactive": 4,
                            "rx_rate_bitrate": 6000,
                            "tx_rate_bitrate": 541600,
                            "rx_rate_chwidth": 40,
                            "fingerprint": "unknown"
                        }
                    ],
                    "timestamp": "2026-02-04T21:00:35+05:30"
                }
            ],
            "mesh": [
                {
                    "bssid": "de:62:79:65:30:7d",
                    "ssid": "DEFAULT-MESH",
                    "band": "5",
                    "channel": 149,
                    "mode": "mesh",
                    "clients": [
                        {
                            "station": "b6:6a:d4:45:e9:60",
                            "rssi": -23,
                            "connected": 2465,
                            "inactive": 0,
                            "rx_rate_bitrate": 103200,
                            "tx_rate_bitrate": 97400,
                            "rx_rate_chwidth": 40
                        }
                    ],
                    "timestamp": "2026-02-04T21:00:35+05:30"
                }
            ],
            "connected": true
        }
    ],
    "edges": {
        "wired": [],
        "mesh": [
            {
                "from": "b46ad445e95c",
                "to": "dc627965307e",
                "ssid": "DEFAULT-MESH",
                "band": "5",
                "channel": 149
            },
            {
                "from": "dc627965307e",
                "to": "b46ad445e95c",
                "ssid": "DEFAULT-MESH",
                "band": "5",
                "channel": 149
            }
        ]
    }
}`


screenshot for First Scenario : 

it's clearly showing device send the state message in latest order and only that device will show it's sta .

<img width="1840" height="932" alt="Screenshot from 2026-02-04 21-03-47" src="https://github.com/user-attachments/assets/ec39f90c-734f-4b53-abfa-522e19edc735" />
