### PR TITLE
updated serviceRPC version in go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 
 require (
 	github.com/go-playground/validator/v10 v10.30.2
-	github.com/routerarchitects/ow-common-mods/servicerpc v0.2.0
+	github.com/routerarchitects/ow-common-mods/servicerpc v0.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/routerarchitects/ow-common-mods/fiber/system-routes v0.1.0 h1:pf8Ooms
 github.com/routerarchitects/ow-common-mods/fiber/system-routes v0.1.0/go.mod h1:MhRZGJhEv+EqrG/U/PTIvNz8g7Rg428v0qi5PCO4nLw=
 github.com/routerarchitects/ow-common-mods/servicediscovery v0.2.0 h1:u/dWm7tICCovDQCSGRVQTEDegL62TOviPpp7T8aLLOY=
 github.com/routerarchitects/ow-common-mods/servicediscovery v0.2.0/go.mod h1:kE7xqdKuCMX6uE9jTnf/PWpSNZe0aVM5zQqNJ2NSPOc=
-github.com/routerarchitects/ow-common-mods/servicerpc v0.2.0 h1:i8Y77pwyJYjqoDf6k68SrQCoQl09g4d8BuHqkbv+hts=
-github.com/routerarchitects/ow-common-mods/servicerpc v0.2.0/go.mod h1:LP5BcstE8j0qd+VtW757WfY5E0FV6WE9MhI4YvlURG8=
+github.com/routerarchitects/ow-common-mods/servicerpc v0.3.0 h1:EztpPc8R5TzrpgIgd7x2g1JvexeadEU0cVHOpkPbM9A=
+github.com/routerarchitects/ow-common-mods/servicerpc v0.3.0/go.mod h1:LP5BcstE8j0qd+VtW757WfY5E0FV6WE9MhI4YvlURG8=
 github.com/routerarchitects/ra-common-mods/apperror v0.2.0 h1:/otTh1Z1VTT0eSdKU0uoPCoquhbRm/lyr36QI09V2L0=
 github.com/routerarchitects/ra-common-mods/apperror v0.2.0/go.mod h1:tCSnjL1XnUDhxt4iIQsPOeecEyDhtpBbUyj+aMAkF2A=
 github.com/routerarchitects/ra-common-mods/buildinfo v0.1.0 h1:S/KlzzEInnAYv0YsNqYlhnBp/rPWwo/oJfAKKF80peU=


### PR DESCRIPTION
## Summary 
This PR updates the servicerpc dependency used by the Network Topology service from v0.2.0 to v0.3.0.

## Changes 
Updated github.com/routerarchitects/ow-common-mods/servicerpc:
From v0.2.0
To v0.3.0
Updated the corresponding dependency checksums in go.sum.